### PR TITLE
112: Added separate db for testing

### DIFF
--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -12,7 +12,7 @@ development:
 
 test:
   <<: *settings
-  database: juniorjobs
+  database: juniorjobs_testing
   user: postgres
   password: root
   host: 127.0.0.1


### PR DESCRIPTION
Issue #ID 112.

### Description

Creating separate DB for testing in order to use `database_cleaner` gem

### Testing steps
* Step 1
run `bin/setup`
* Step 2
Check that database `juniorjobs_testing` was created